### PR TITLE
Fixes jzaiat/redshares#13 for case when Role got deleted

### DIFF
--- a/app/views/redshares/_new.html.erb
+++ b/app/views/redshares/_new.html.erb
@@ -18,7 +18,7 @@
                  :project_id => @project) }')" %>
 
   <div id="users_for_redshare">
-    <%= principals_check_box_tags 'redshare[user_ids][]', (redshared ? redshared.addable_redshare_users : nil) %>
+    <%= principals_check_box_tags 'redshare[user_ids][]', (redshared ? redshared.addable_redshare_users.compact : nil) %>
   </div>
   
   <div id="roles_for_redshare">

--- a/lib/acts_as_redshareable.rb
+++ b/lib/acts_as_redshareable.rb
@@ -32,7 +32,7 @@ module Redmine
         # Returns an array of users that are proposed as redshares
         def addable_redshare_users
           members = self.project.users_by_role()
-          filter_roles = Role.find(Redshares.settings['roles'])
+          filter_roles = Role.where(:id => Redshares.settings['roles'])
           valid_users = filter_roles.map{|r| members[r]}.flatten
           valid_users.uniq! #remove duplicates
           #disallow to redshare to assigned


### PR DESCRIPTION
For my particular case this error was caused by the admin who removed Role. Plugin settings were kept intact, so they were trying to find Role deleted returning 404 for AJAX call.
